### PR TITLE
salt.loader entrypoints, py27, ftw?

### DIFF
--- a/legion/loader.py
+++ b/legion/loader.py
@@ -1,0 +1,17 @@
+import os
+
+PKG_DIR = os.path.abspath(os.path.dirname(__file__))
+
+
+def returner_dirs():
+    """
+    yield one path per parent directory of where returner modules can be found
+    """
+    yield os.path.join(PKG_DIR, "returners")
+
+
+def module_dirs():
+    """
+    yield one path per parent directory of where execution modules can be found
+    """
+    yield os.path.join(PKG_DIR, "modules")

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name="legion",
-    version="1.0.0",
+    version="1.0.1",
     packages=[
         "legion",
         "legion/modules",
@@ -11,6 +11,10 @@ setup(
     entry_points={
         'console_scripts': [
             'legion=legion.legion:main',
+        ],
+        'salt.loader': [
+            'module_dirs=legion.loader:module_dirs',
+            'returner_dirs=legion.loader:returner_dirs',
         ],
     },
 )


### PR DESCRIPTION
* add `salt.loader` entrypoints to `setup.py`
* add `__init__.py` so python 2.7 can find the module. fail
* increment version to 1.0.1